### PR TITLE
Inline preload-type components

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -50,7 +50,7 @@ const navLinks: Array<NavLink> = [
     <a class="navbar-item" href="/">
       <div id="logo-text">{siteInfo.title}</div>
     </a>
-    <NavModalToggle client:load />
+    <NavModalToggle client:idle />
   </div>
   <div class="navbar-menu">
     <div class="navbar-end">

--- a/src/components/head/BaseHead.astro
+++ b/src/components/head/BaseHead.astro
@@ -49,8 +49,8 @@ const { title, description, image = "/img/about.jpg" } = Astro.props;
 
 <!-- immediately fetch fonts and icons -->
 <Variables />
-<GlobalStyles />
 <Preload />
+<GlobalStyles />
 
 <!-- load google analytics tag -->
 <GoogleAnalytics id={googleAnalyticsDestinationId} />

--- a/src/components/head/GlobalStyles.astro
+++ b/src/components/head/GlobalStyles.astro
@@ -4,7 +4,7 @@
  */
 ---
 
-<style is:global>
+<style is:global is:inline>
   html {
     /* prevent any overflow outside of the html element. */
     /* overflow: hidden !important; */

--- a/src/components/head/Preload.astro
+++ b/src/components/head/Preload.astro
@@ -5,7 +5,7 @@
  */
 ---
 
-<style is:global>
+<style is:global is:inline>
   /**
    * DISPLAY FONT - Titles, logos, etc.
    */

--- a/src/components/head/Variables.astro
+++ b/src/components/head/Variables.astro
@@ -4,7 +4,7 @@
  */
 ---
 
-<style is:global>
+<style is:global is:inline>
   html {
     /** COLORS */
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,11 +69,20 @@ const sections: Array<{
         margin-right: auto;
       }
 
-      .home-columns {
+      .home-columns-container {
+        display: flex;
+        flex-flow: row nowrap;
         justify-content: center;
-        margin-top: 1rem;
+      }
 
-        .column {
+      .home-columns {
+        display: grid;
+        margin: 1rem auto;
+        grid-template-columns: repeat(3, minmax(20rem, 35rem));
+        grid-template-rows: 1fr;
+        grid-column-gap: 5rem;
+
+        .home-column {
           text-align: center;
         }
 
@@ -149,12 +158,12 @@ const sections: Array<{
           </div>
         </div>
       </section>
-      <section>
-        <div class="columns home-columns">
+      <section class="home-columns-container">
+        <div class="home-columns">
           {
             sections.map(({ href, svg, name, tagline }) => {
               return (
-                <div class="column is-3-desktop is-4-tablet-only">
+                <div class="home-column">
                   <a href={href} class="home-link">
                     <InlineSvg svg={svg} className="column-logo" />
                     <InlineSvg svg={diamondsSvg} className="hero-diamonds" />


### PR DESCRIPTION
Existing preload / important css components are currently being loaded separately as scripts, leading to FOUT. Fixing these to inline these.