### PR TITLE
Remove bulma columns in favor of CSS Grid

### DIFF
--- a/src/components/head/GlobalStyles.astro
+++ b/src/components/head/GlobalStyles.astro
@@ -4,7 +4,7 @@
  */
 ---
 
-<style is:global is:inline>
+<style is:global>
   html {
     /* prevent any overflow outside of the html element. */
     /* overflow: hidden !important; */

--- a/src/layouts/About.astro
+++ b/src/layouts/About.astro
@@ -48,6 +48,7 @@ const { frontmatter } = Astro.props;
   <head>
     <BaseHead title={frontmatter.title} description={frontmatter.description} />
     <style lang="scss">
+      @use "../../node_modules/bulma/sass/utilities/mixins.sass" as mixins;
       @import "../../node_modules/bulma/sass/components/card.sass";
       #about-container {
         margin-bottom: 3rem;
@@ -121,6 +122,28 @@ const { frontmatter } = Astro.props;
           width: 100%;
         }
       }
+
+      .about-columns {
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 38rem 24rem;
+        grid-gap: 1rem;
+        justify-content: center;
+      }
+
+      @include mixins.touch {
+        .about-columns {
+          grid-template-columns: 30rem 15rem;
+        }
+      }
+
+      @include mixins.mobile {
+        .about-columns {
+          margin: 0 2rem;
+          grid-template-columns: 1fr;
+          grid-gap: 3rem;
+        }
+      }
     </style>
   </head>
   <body>
@@ -129,14 +152,14 @@ const { frontmatter } = Astro.props;
     <main>
       <div class="container" id="about-container">
         <Hero title="About" />
-        <div class="columns is-centered">
-          <div class="column is-6">
+        <div class="about-columns">
+          <div class="about-column">
             <MarkdownContent>
               <slot />
             </MarkdownContent>
           </div>
 
-          <div class="column is-4">
+          <div class="about-column">
             <div class="card" id="about-card">
               <!-- image -->
               <div class="card-image">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,11 +69,40 @@ const sections: Array<{
         margin-right: auto;
       }
 
-      .home-columns {
-        justify-content: center;
-        margin-top: 1rem;
+      $columnWidth: 20rem;
+      $columnCount: 3;
+      $columnGap: 2rem;
 
-        .column {
+      .home-columns-container {
+        display: flex;
+        flex-flow: row nowrap;
+        justify-content: center;
+      }
+
+      .home-columns {
+        display: grid;
+        margin: 1rem auto;
+        grid-template-columns: repeat($columnCount, $columnWidth);
+        grid-column-gap: $columnGap;
+        grid-template-rows: 1fr;
+
+        @include mixins.touch {
+          & {
+            grid-template-columns: repeat(
+              $columnCount,
+              calc($columnWidth - 4rem)
+            );
+            grid-column-gap: 0rem;
+          }
+        }
+
+        @include mixins.mobile {
+          & {
+            grid-template-columns: 100%;
+          }
+        }
+
+        .home-column {
           text-align: center;
         }
 
@@ -149,12 +178,12 @@ const sections: Array<{
           </div>
         </div>
       </section>
-      <section>
-        <div class="columns home-columns">
+      <section class="home-columns-container">
+        <div class="home-columns">
           {
             sections.map(({ href, svg, name, tagline }) => {
               return (
-                <div class="column is-3-desktop is-4-tablet-only">
+                <div class="home-column">
                   <a href={href} class="home-link">
                     <InlineSvg svg={svg} className="column-logo" />
                     <InlineSvg svg={diamondsSvg} className="hero-diamonds" />

--- a/src/styles/custom_bulma.scss
+++ b/src/styles/custom_bulma.scss
@@ -9,7 +9,6 @@
 // 3. import the rest of bulma that we care about
 @import "../../node_modules/bulma/sass/utilities/_all.sass";
 @import "../../node_modules/bulma/sass/base/generic.sass";
-@import "../../node_modules/bulma/sass/grid/columns.sass";
 @import "../../node_modules/bulma/sass/components/modal.sass";
 @import "../../node_modules/bulma/sass/components/navbar.sass";
 @import "../../node_modules/bulma/sass/elements/container.sass";


### PR DESCRIPTION
The columns is one of the largest contributors to the big CSS payload size on the page right now. Nixing this saves a _huge_ percentage of the size.